### PR TITLE
Add Redis ACL and TLS configuration files

### DIFF
--- a/redis/compose.tls.yml
+++ b/redis/compose.tls.yml
@@ -1,24 +1,24 @@
 services:
-  # https://redis.io/docs/management/security/encryption/
+  # https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
   redis:
-    command: 
-     - --port 6379
-     - --tls-port 6380
-     - --tls-cert-file /run/secrets/dev.local.crt
-     - --tls-key-file /run/secrets/dev.local.key
-     - --tls-ca-cert-file /run/secrets/dev.CA.crt
-     - --tls-auth-clients no
+    volumes:
+      - redis_data:/data
+      - ./etc:/usr/local/etc/redis:ro
+    command: /usr/local/etc/redis/redis.conf
+    healthcheck:
+      test: redis-cli -h localhost -p 6380 --tls --insecure ping
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     ports:
       - 127.0.0.1:6380:6380
     secrets:
-      - dev.CA.crt
-      - dev.local.crt
-      - dev.local.key
+      - server.crt
+      - server.key
 
 secrets:
-  dev.CA.crt:
+  server.crt:
     external: true
-  dev.local.crt:
-    external: true
-  dev.local.key:
+  server.key:
     external: true

--- a/redis/compose.yml
+++ b/redis/compose.yml
@@ -3,12 +3,14 @@ services:
     # https://hub.docker.com/_/redis
     image: docker.io/library/redis
     restart: always
+    healthcheck:
+      test: redis-cli -h localhost -p 6379 ping
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     volumes:
       - redis_data:/data
-      # 如果需要自訂組態的話
-      # - ./etc:/usr/local/etc/redis:ro
-    # 如果需要自訂組態的話
-    # command: /usr/local/etc/redis/redis.conf
     ports:
       - 127.0.0.1:6379:6379
 

--- a/redis/etc/redis.acl
+++ b/redis/etc/redis.acl
@@ -1,0 +1,2 @@
+user default on nopass -@all +ping
+user admin on >changeit ~* &* +@all

--- a/redis/etc/redis.conf
+++ b/redis/etc/redis.conf
@@ -1,0 +1,11 @@
+# https://redis.io/docs/latest/develop/reference/eviction/#eviction-policies
+maxmemory-policy volatile-lru
+
+# https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/#use-an-external-acl-file
+aclfile /usr/local/etc/redis/redis.acl
+
+# https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
+tls-port 6380
+tls-cert-file /run/secrets/server.crt
+tls-key-file /run/secrets/server.key
+tls-auth-clients no


### PR DESCRIPTION
Introduce redis.conf and redis.acl for managing TLS encryption and access control externally. Simplify TLS secret naming, add health checks to both compose files, and update README with revised instructions.